### PR TITLE
changes to move pickle file to falcon gateway

### DIFF
--- a/data_handler.py
+++ b/data_handler.py
@@ -12,7 +12,7 @@ from predict import predict
 
 #raw_json = '{"sepal_length": [6.9], "sepal_width": [3.2], "petal_length": [5.7], "petal_width": [2.3]}'
 
-def invoke_predict(raw_json):
+def invoke_predict(model, raw_json):
 	#convert args_dict to model_usable_data (have to pick model for this first)
 	input_dict = json.loads(raw_json.decode())
 	# make your feature list here the order in which you need your model to accept input
@@ -23,7 +23,7 @@ def invoke_predict(raw_json):
 	model_usable_data = [mapped_inputs] #convert 1D array to 2D array to satisfy model specific requirements
 	
 
-	raw_model_output =  predict(model_usable_data) #requires a predict function that purely returns response. Import up in imports.
+	raw_model_output =  predict(model, model_usable_data) #requires a predict function that purely returns response. Import up in imports.
 	#prediction = json.load(str(raw_model_output)) #convert raw model results to json
 	prediction = str(raw_model_output)
 	return prediction #currently returns string

--- a/falcon_gateway.py
+++ b/falcon_gateway.py
@@ -1,7 +1,8 @@
 # falcon_gateway.py
-
 import falcon
+import os
 import json
+import pickle
 from data_handler import invoke_predict
 
 # Falcon follows the REST architectural style, meaning (among
@@ -51,11 +52,15 @@ class PredictsResource(object):
                 'Malformed JSON',
                 'Could not decode the request body. The '
                 'JSON was incorrect.')
- 
+        
+        # loading model file
+        model_filename = os.path.join('model.dat')
+        model = pickle.load(open(model_filename, 'rb'))
+
         resp.status = falcon.HTTP_200
-        resp.body = json.dumps(invoke_predict(raw_json))  
+        resp.body = json.dumps(invoke_predict(model, raw_json))  
         # For Python 2.x, replace with
-        # resp.body = json.dumps(invoke_predict(raw_json), encoding='utf-8') encoding not necessary in python3.
+        # resp.body = json.dumps(invoke_predict(model, raw_json), encoding='utf-8') encoding not necessary in python3.
          
 
 # falcon.API instances are callable WSGI apps. Never change this.

--- a/predict.py
+++ b/predict.py
@@ -3,9 +3,8 @@
 # 
 # In this exaple, predict would require data of the following datatype:
 # Pandas DataFrame with features 
+# model --> loaded model file in pickle format
 # X_test= [[ 6.9, 3.2, 5.7, 2.3]]
-import os
-import pickle
 import pandas as pd
 import random
 import sklearn
@@ -13,11 +12,9 @@ import sklearn
 random.seed(3)
 
 
-# take input pd data frame and return dictionary with classificaiton
-def predict(X_test):
-	# loading model file
-	model_filename = os.path.join('model.dat')
-	model = pickle.load(open(model_filename, 'rb'))
+# take input pd data frame and loaded model and return dictionary with classificaiton
+def predict(model, X_test):
+	# Class map
 	Species_class_map = {0:'Iris-setosa', 1:'Iris-versicolor', 2:'Iris-virginica'}
 
 	# Test feature


### PR DESCRIPTION
Moved the unpickling of the model to the falcon gateway to ensure that we are not repickling the same file over and over when a request is made to the API. 